### PR TITLE
feat: 자동 주기 VLM 분석 + 실시간 모션 감지 추가

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,9 @@
 import cv2
 import os
+import queue
+import threading
+import time
+import argparse
 import pandas as pd
 from datetime import datetime
 
@@ -9,28 +13,27 @@ from hvac_simulator import HVACSimulator
 from thermal_engine import ThermalEngine
 from state_machine import StateManager, SystemState
 from energy_monitor import EnergyMonitor
+from motion_detector import MotionDetector
 
 # ─── 설정 상수 ───────────────────────────────────────────────────────────────
 LOG_FILE      = "hvac_system_performance.csv"
 SCENARIO_NAME = "Smart_Office_Initial_Test"
 
 WEATHER_API_KEY = "97e9ad342e69a006e6c55886b18842c2"
-WEATHER_LAT     = 35.1044   # 사하구, 부산 위도
-WEATHER_LON     = 128.9750  # 사하구, 부산 경도
+WEATHER_LAT     = 35.1044
+WEATHER_LON     = 128.9750
 
-ROOM_SIZE_M2    = 20.0   # 방 면적 (m²)
-WINDOW_OPEN     = False  # 창문 초기 상태
+ROOM_SIZE_M2    = 20.0
+WINDOW_OPEN     = False
 
-WORK_START_HOUR = 9      # 근무 시작 시각
-WORK_END_HOUR   = 18     # 근무 종료 시각
+WORK_START_HOUR = 9
+WORK_END_HOUR   = 18
 
-# 풍량 단계 → 실내 기류 속도(m/s) 변환 (PMV vel 입력용)
 FAN_VELOCITY = {1: 0.1, 2: 0.3, 3: 0.5}
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 def initialize_csv():
-    """CSV 로그 파일이 없으면 헤더 포함 신규 생성"""
     if not os.path.exists(LOG_FILE):
         columns = [
             'timestamp', 'scenario',
@@ -39,6 +42,7 @@ def initialize_csv():
             'in_temp', 'in_humid',
             'people_count', 'met', 'clo', 'activity',
             'bags', 'heat_source',
+            'motion_score', 'met_source',
             'window_open', 'room_size', 'air_vel',
             'pmv_val', 'comfort_status',
             'target_temp', 'fan_speed',
@@ -49,42 +53,22 @@ def initialize_csv():
 
 
 def save_log(data: dict):
-    """딕셔너리 한 행을 CSV에 추가"""
     pd.DataFrame([data]).to_csv(LOG_FILE, mode='a', index=False, header=False)
 
 
 def decide_control(state: SystemState, pmv_val: float,
                    people_count: int, outdoor_temp: float):
-    """
-    상태 머신 + PMV 기반 공조기 제어 명령 결정
-
-    ── 상태별 동작 ──────────────────────────────────────────────────────────
-    EMPTY         : 전원 OFF (빈 공간 절전)
-    ARRIVAL       : 도착 직후 적극적 냉·난방 (외기 온도 기반)
-    PRE_DEPARTURE : 목표온도 완화 + 풍량 최소 (점진적 절전)
-    STEADY        : ISO 7730 PMV 기반 미세 제어
-
-    Returns:
-        (power: bool|None, target_temp: float|None, fan_speed: int|None)
-        power=None  이면 현재 설정 유지
-        power=False 이면 공조기 OFF
-    """
     if state == SystemState.EMPTY:
         return False, None, None
-
     if state == SystemState.ARRIVAL:
-        if outdoor_temp > 25.0:          # 여름: 빠른 냉방
+        if outdoor_temp > 25.0:
             return True, 20.0, 3
-        elif outdoor_temp < 10.0:        # 겨울: 빠른 난방
+        elif outdoor_temp < 10.0:
             return True, 26.0, 3
-        else:                            # 봄/가을: 표준
+        else:
             return True, 22.0, 2
-
     if state == SystemState.PRE_DEPARTURE:
-        # 잔열·잔냉 활용, 풍량 최소 → 에너지 절약
         return True, 25.0, 1
-
-    # STEADY: PMV 기반 제어
     if pmv_val > 0.5:
         occ_offset  = min(2.0, max(0, people_count - 1) * 0.5)
         target_temp = round(22.0 - occ_offset, 1)
@@ -93,26 +77,12 @@ def decide_control(state: SystemState, pmv_val: float,
     elif pmv_val < -0.5:
         return True, 26.0, 1
     else:
-        return None, None, None  # 쾌적 상태: 현재 유지
+        return None, None, None
 
 
 def decide_window(state: SystemState, pmv_val: float,
                   outdoor_temp: float, indoor_temp: float,
-                  heat_source: str) -> bool | None:
-    """
-    자동 창문 제어 결정
-
-    ── 우선순위 ─────────────────────────────────────────────────────────────
-    1. EMPTY       → 닫기 (보안)
-    2. 열원 감지    → 열기 (환기 우선)
-    3. PRE_DEPARTURE → 닫기 (퇴근 준비)
-    4. STEADY + 더움 + 외기가 내부보다 시원 → 열기 (자연환기)
-
-    Returns:
-        True  : 창문 열기
-        False : 창문 닫기
-        None  : 현재 상태 유지 (수동 조작 유지)
-    """
+                  heat_source: str):
     if state == SystemState.EMPTY:
         return False
     if heat_source == 'yes':
@@ -125,206 +95,286 @@ def decide_window(state: SystemState, pmv_val: float,
 
 
 def build_hud(hvac: HVACSimulator, state: SystemState,
-              energy: EnergyMonitor, departure_score: int) -> list[str]:
-    """실시간 HUD 텍스트 2줄 생성"""
+              energy: EnergyMonitor, departure_score: int,
+              motion_score: float) -> list:
     win  = "O" if hvac.window_open else "C"
     mode = "ON" if hvac.is_on else "OFF"
-
     line1 = (f"Temp:{hvac.indoor_temp:.1f}C  Humid:{hvac.indoor_humid:.1f}%  "
              f"AC:{mode}({hvac.target_temp:.0f}C/Fan{hvac.fan_speed})  Win:{win}")
-
     line2 = (f"State:{state.value}  Score:{departure_score}  "
+             f"Motion:{motion_score:.1f}  "
              f"Save:{energy.get_savings_pct():.1f}%  "
-             f"Comfort:{energy.get_comfort_rate():.1f}%  "
              f"Power:{energy.get_current_power_w(hvac.is_on, hvac.fan_speed)}W")
-
     return [line1, line2]
 
 
-def main():
+# ── VLM 백그라운드 스레드 ─────────────────────────────────────────────────────
+
+def vlm_worker(vlm, frame_lock, shared_frame_ref,
+               result_queue, stop_event, interval):
+    """
+    interval초마다 VLM 분석을 실행하고 결과를 Queue에 적재합니다.
+    CPU 개발환경: 30초 권장 / Jetson(TensorRT): 5~10초 가능.
+    """
+    while not stop_event.is_set():
+        elapsed = 0.0
+        while elapsed < interval and not stop_event.is_set():
+            time.sleep(0.5)
+            elapsed += 0.5
+
+        if stop_event.is_set():
+            break
+
+        with frame_lock:
+            if shared_frame_ref[0] is None:
+                continue
+            frame_copy = shared_frame_ref[0].copy()
+
+        print("\n🤖 [VLM-Thread] 자동 분석 시작...")
+        result = vlm.analyze_frame(frame_copy)
+
+        if result is None:
+            print("⚠️ [VLM-Thread] 분석 실패, 건너뜀")
+            continue
+
+        try:
+            result_queue.get_nowait()
+        except queue.Empty:
+            pass
+        result_queue.put_nowait(result)
+        print("✅ [VLM-Thread] 결과 적재 완료")
+
+
+# ── VLM 결과 처리 ─────────────────────────────────────────────────────────────
+
+def process_vlm_result(vlm_data, motion_det, hvac, sm, engine, em,
+                       out_temp, out_humid, out_weather, out_wind):
+    people_count = vlm_data['count']
+
+    print(f"📊 [VLM] Met={vlm_data['met']}  Clo={vlm_data['clo']}  "
+          f"인원={people_count}명  활동={vlm_data['activity']}  "
+          f"가방={vlm_data['bags']}  열원={vlm_data['heat_source']}")
+
+    current_state = sm.update(
+        people_count=people_count,
+        outerwear=vlm_data['outerwear'],
+        activity=vlm_data['activity'],
+        bags=vlm_data['bags'],
+    )
+    print(f"🔄 [State] {current_state.value}  (퇴근 점수: {sm.departure_score})")
+
+    # MET 결정: motion override 여부
+    if motion_det.should_override_vlm():
+        effective_met = motion_det.get_motion_met()
+        met_source    = "motion"
+    else:
+        effective_met = vlm_data['met']
+        met_source    = "vlm"
+    print(f"🏃 [MET] {met_source} 기반: {effective_met} met  "
+          f"(motion_score={motion_det.current_score:.1f})")
+
+    # tr 보정 (열원 감지 시 +4°C)
+    tr_corrected = hvac.indoor_temp
+    if vlm_data['heat_source'] == 'yes':
+        tr_corrected += VLMProcessor.TR_HEAT_OFFSET
+        print(f"🔥 [Thermal] 열원 감지 → tr 보정: {hvac.indoor_temp:.1f} → {tr_corrected:.1f}°C")
+
+    # PMV 계산
+    air_vel = FAN_VELOCITY.get(hvac.fan_speed, 0.1)
+    pmv_val = engine.calculate_pmv(
+        ta=hvac.indoor_temp, tr=tr_corrected,
+        rh=hvac.indoor_humid, vel=air_vel,
+        met=effective_met, clo=vlm_data['clo'],
+    )
+    comfort_msg = engine.get_comfort_status(pmv_val)
+    print(f"🌡️ [PMV] {pmv_val:.2f}  ({comfort_msg})")
+
+    em.tick(hvac.is_on, hvac.fan_speed, people_count, pmv_val)
+
+    # 자동 창문 제어
+    window_cmd = decide_window(current_state, pmv_val, out_temp,
+                               hvac.indoor_temp, vlm_data['heat_source'])
+    if window_cmd is not None and hvac.window_open != window_cmd:
+        hvac.window_open = window_cmd
+        reason = ("열원/환기" if vlm_data['heat_source'] == 'yes'
+                  else "퇴근 준비" if current_state == SystemState.PRE_DEPARTURE
+                  else "자연환기" if window_cmd else "빈 공간")
+        print(f"🪟 [Window] 자동 {'열림' if window_cmd else '닫힘'} ({reason})")
+
+    hvac.simulate_step(out_temp, out_humid, people_count=people_count)
+
+    # 공조기 제어
+    print("🎮 [Control] 제어 명령 하달")
+    power, target_temp, fan_speed = decide_control(
+        current_state, pmv_val, people_count, out_temp)
+
+    if power is False:
+        print("  → 빈 공간: 공조기 OFF")
+        hvac.set_control(power=False, target=hvac.target_temp, fan=1)
+        target_temp = hvac.target_temp
+        fan_speed   = hvac.fan_speed
+    elif power is True:
+        label = {
+            SystemState.ARRIVAL:       "도착 초기 강제 냉·난방",
+            SystemState.PRE_DEPARTURE: "퇴근 준비 절전 모드",
+            SystemState.STEADY:        "냉방 강화" if pmv_val > 0.5 else "난방/절전",
+        }.get(current_state, "제어")
+        print(f"  → {label}: 목표 {target_temp}°C, 풍량 {fan_speed}")
+        hvac.set_control(power=True, target=target_temp, fan=fan_speed)
+    else:
+        print("  → 쾌적 상태 유지 (변경 없음)")
+        target_temp = hvac.target_temp
+        fan_speed   = hvac.fan_speed
+
+    return {
+        'timestamp':       datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+        'scenario':        SCENARIO_NAME,
+        'system_state':    current_state.value,
+        'departure_score': sm.departure_score,
+        'out_temp':        out_temp,
+        'out_humid':       out_humid,
+        'out_weather':     out_weather,
+        'out_wind':        out_wind,
+        'in_temp':         hvac.indoor_temp,
+        'in_humid':        hvac.indoor_humid,
+        'people_count':    people_count,
+        'met':             effective_met,
+        'clo':             vlm_data['clo'],
+        'activity':        vlm_data['activity'],
+        'bags':            vlm_data['bags'],
+        'heat_source':     vlm_data['heat_source'],
+        'motion_score':    round(motion_det.current_score, 2),
+        'met_source':      met_source,
+        'window_open':     hvac.window_open,
+        'room_size':       hvac.room_size,
+        'air_vel':         air_vel,
+        'pmv_val':         pmv_val,
+        'comfort_status':  comfort_msg,
+        'target_temp':     target_temp,
+        'fan_speed':       fan_speed,
+        'power_w':         em.get_current_power_w(hvac.is_on, hvac.fan_speed),
+        'energy_kwh':      em.get_energy_kwh(),
+        'baseline_kwh':    em.get_baseline_kwh(),
+        'savings_pct':     em.get_savings_pct(),
+        'comfort_rate':    em.get_comfort_rate(),
+    }
+
+
+# ── 메인 ──────────────────────────────────────────────────────────────────────
+
+def main(analysis_interval: int = 30):
     print("⚙️ [System] 지능형 공조 제어 시스템 초기화 중...")
     initialize_csv()
 
-    vlm     = VLMProcessor()
-    weather = WeatherService(lat=WEATHER_LAT, lon=WEATHER_LON, api_key=WEATHER_API_KEY)
-    hvac    = HVACSimulator(room_size=ROOM_SIZE_M2)
+    vlm        = VLMProcessor()
+    weather    = WeatherService(lat=WEATHER_LAT, lon=WEATHER_LON, api_key=WEATHER_API_KEY)
+    hvac       = HVACSimulator(room_size=ROOM_SIZE_M2)
     hvac.set_room(ROOM_SIZE_M2, WINDOW_OPEN)
-    engine  = ThermalEngine()
-    sm      = StateManager(work_start_hour=WORK_START_HOUR, work_end_hour=WORK_END_HOUR)
-    em      = EnergyMonitor()
+    engine     = ThermalEngine()
+    sm         = StateManager(work_start_hour=WORK_START_HOUR, work_end_hour=WORK_END_HOUR)
+    em         = EnergyMonitor()
+    motion_det = MotionDetector(history_len=10, blur_ksize=21)
 
     cap = cv2.VideoCapture(0)
     if not cap.isOpened():
         print("❌ [Error] 카메라를 열 수 없습니다.")
         return
 
+    # ── 스레딩 공유 자원 ────────────────────────────────────────────────────
+    frame_lock       = threading.Lock()
+    shared_frame_ref = [None]               # Lock으로 보호되는 최신 프레임
+    result_queue     = queue.Queue(maxsize=1)
+    stop_event       = threading.Event()
+
+    vlm_thread = threading.Thread(
+        target=vlm_worker,
+        args=(vlm, frame_lock, shared_frame_ref,
+              result_queue, stop_event, analysis_interval),
+        daemon=True,
+        name="VLM-Background",
+    )
+    vlm_thread.start()
+
     print("\n✅ 모든 모듈 준비 완료!")
     print(f"📍 날씨 조회: ({WEATHER_LAT}, {WEATHER_LON})  |  방 크기: {ROOM_SIZE_M2}m²")
     print(f"🕐 근무 시간: {WORK_START_HOUR}:00 ~ {WORK_END_HOUR}:00")
-    print("⌨️  's': 분석 및 제어  |  'w': 창문 수동 개폐  |  'q': 종료\n")
+    print(f"⏱️  자동 VLM 분석: {analysis_interval}초마다  (수동: 's' 키)")
+    print("⌨️  's': 즉시 분석  |  'w': 창문 수동 개폐  |  'q': 종료\n")
 
     last_people_count = 0
-    pmv_val           = 0.0
-    out_temp          = 20.0
-    out_humid         = 50.0
-    out_weather       = "unknown"
-    out_wind          = 0.0
+    out_temp    = 20.0
+    out_humid   = 50.0
+    out_weather = "unknown"
+    out_wind    = 0.0
 
     while True:
         ret, frame = cap.read()
         if not ret:
             break
 
-        # ── 매 프레임 처리 ────────────────────────────────────────────────────
+        # ── 공유 프레임 갱신 ────────────────────────────────────────────────
+        with frame_lock:
+            shared_frame_ref[0] = frame.copy()
+
+        # ── 모션 감지 (매 프레임) ────────────────────────────────────────────
+        motion_det.update(frame)
+
+        # ── 기상·시뮬·에너지 갱신 ───────────────────────────────────────────
         out_temp, out_humid, out_weather, out_wind = weather.fetch_current_weather()
         hvac.simulate_step(out_temp, out_humid, people_count=last_people_count)
         em.tick(hvac.is_on, hvac.fan_speed, last_people_count)
 
-        # HUD 오버레이 (2줄)
-        hud_lines = build_hud(hvac, sm.state, em, sm.departure_score)
-        cv2.putText(frame, hud_lines[0], (10, 30), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 255, 0), 2)
-        cv2.putText(frame, hud_lines[1], (10, 58), cv2.FONT_HERSHEY_SIMPLEX, 0.45, (0, 200, 255), 1)
+        # ── VLM 결과 Queue 폴링 (비블로킹) ──────────────────────────────────
+        try:
+            vlm_data = result_queue.get_nowait()
+            last_people_count = vlm_data['count']
+            log_row = process_vlm_result(
+                vlm_data, motion_det, hvac, sm, engine, em,
+                out_temp, out_humid, out_weather, out_wind,
+            )
+            save_log(log_row)
+            print(f"💾 [Log] {LOG_FILE} 저장 완료\n")
+        except queue.Empty:
+            pass
+
+        # ── HUD 렌더링 ───────────────────────────────────────────────────────
+        hud_lines = build_hud(hvac, sm.state, em, sm.departure_score,
+                              motion_det.current_score)
+        cv2.putText(frame, hud_lines[0], (10, 30),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 255, 0), 2)
+        cv2.putText(frame, hud_lines[1], (10, 58),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.42, (0, 200, 255), 1)
         cv2.imshow('VLM Intelligent HVAC System', frame)
 
         key = cv2.waitKey(1) & 0xFF
 
-        # ── 창문 수동 개폐 토글 ('w') ─────────────────────────────────────────
+        # ── 창문 수동 토글 ('w') ─────────────────────────────────────────────
         if key == ord('w'):
             hvac.window_open = not hvac.window_open
-            print(f"🪟 [Window] 수동 조작: {'열림 (OPEN)' if hvac.window_open else '닫힘 (CLOSED)'}")
+            print(f"🪟 [Window] 수동: {'열림' if hvac.window_open else '닫힘'}")
 
-        # ── 분석 및 제어 루프 ('s') ───────────────────────────────────────────
+        # ── 즉시 수동 분석 ('s') ─────────────────────────────────────────────
         elif key == ord('s'):
-            print("\n🔍 [Step 1] VLM 시각 분석 시작...")
-            vlm_data = vlm.analyze_frame(frame)
-
-            if not vlm_data:
-                print("⚠️ [Warning] VLM 분석 실패. 's'를 다시 눌러 재시도하세요.")
-                continue
-
-            last_people_count = vlm_data['count']
-            print(f"📊 [Step 2] 분석 결과: "
-                  f"Met={vlm_data['met']}  Clo={vlm_data['clo']}  "
-                  f"인원={last_people_count}명  "
-                  f"활동={vlm_data['activity']}  "
-                  f"가방={vlm_data['bags']}  "
-                  f"열원={vlm_data['heat_source']}")
-
-            # ── 상태 머신 갱신 ────────────────────────────────────────────────
-            current_state = sm.update(
-                people_count=last_people_count,
-                outerwear=vlm_data['outerwear'],
-                activity=vlm_data['activity'],
-                bags=vlm_data['bags'],
-            )
-            print(f"🔄 [State] 현재 상태: {current_state.value}  "
-                  f"(퇴근 맥락 점수: {sm.departure_score})")
-
-            # ── tr 보정 (열원 감지 시 복사온도 상향) ─────────────────────────
-            tr_corrected = hvac.indoor_temp
-            if vlm_data['heat_source'] == 'yes':
-                tr_corrected += VLMProcessor.TR_HEAT_OFFSET
-                print(f"🔥 [Thermal] 열원 감지 → 복사온도 보정: {hvac.indoor_temp:.1f}°C → {tr_corrected:.1f}°C")
-
-            # ── PMV 계산 ──────────────────────────────────────────────────────
-            air_vel = FAN_VELOCITY.get(hvac.fan_speed, 0.1)
-            pmv_val = engine.calculate_pmv(
-                ta=hvac.indoor_temp,
-                tr=tr_corrected,
-                rh=hvac.indoor_humid,
-                vel=air_vel,
-                met=vlm_data['met'],
-                clo=vlm_data['clo'],
-            )
-            comfort_msg = engine.get_comfort_status(pmv_val)
-            print(f"🌡️ [Step 3] PMV: {pmv_val:.2f}  ({comfort_msg})")
-
-            # PMV 쾌적도 통계 업데이트
-            em.tick(hvac.is_on, hvac.fan_speed, last_people_count, pmv_val)
-
-            # ── 자동 창문 제어 ────────────────────────────────────────────────
-            window_cmd = decide_window(
-                state=current_state,
-                pmv_val=pmv_val,
-                outdoor_temp=out_temp,
-                indoor_temp=hvac.indoor_temp,
-                heat_source=vlm_data['heat_source'],
-            )
-            if window_cmd is not None:
-                if hvac.window_open != window_cmd:
-                    hvac.window_open = window_cmd
-                    reason = ("열원/환기 필요" if vlm_data['heat_source'] == 'yes'
-                              else "퇴근 준비" if current_state == SystemState.PRE_DEPARTURE
-                              else "자연환기 조건 충족" if window_cmd
-                              else "빈 공간")
-                    print(f"🪟 [Window] 자동 {'열림' if window_cmd else '닫힘'} ({reason})")
-
-            # ── 인원 반영 시뮬레이션 재갱신 ──────────────────────────────────
-            hvac.simulate_step(out_temp, out_humid, people_count=last_people_count)
-
-            # ── 공조기 제어 결정 ──────────────────────────────────────────────
-            print("🎮 [Step 4] 공조기 제어 명령 하달")
-            power, target_temp, fan_speed = decide_control(
-                state=current_state,
-                pmv_val=pmv_val,
-                people_count=last_people_count,
-                outdoor_temp=out_temp,
-            )
-
-            if power is False:
-                print("  → 빈 공간 / 퇴근 완료: 공조기 OFF")
-                hvac.set_control(power=False, target=hvac.target_temp, fan=1)
-                target_temp = hvac.target_temp
-                fan_speed   = hvac.fan_speed
-            elif power is True:
-                label = {
-                    SystemState.ARRIVAL:       "도착 초기 강제 냉·난방",
-                    SystemState.PRE_DEPARTURE: "퇴근 준비 절전 모드",
-                    SystemState.STEADY:        "냉방 강화" if pmv_val > 0.5 else "난방/절전",
-                }.get(current_state, "제어")
-                print(f"  → {label}: 목표 {target_temp}°C, 풍량 {fan_speed}")
-                hvac.set_control(power=True, target=target_temp, fan=fan_speed)
+            print("\n🔍 [Manual] 즉시 VLM 분석 시작 (블로킹)...")
+            with frame_lock:
+                frame_copy = shared_frame_ref[0].copy()
+            vlm_data = vlm.analyze_frame(frame_copy)
+            if vlm_data:
+                last_people_count = vlm_data['count']
+                log_row = process_vlm_result(
+                    vlm_data, motion_det, hvac, sm, engine, em,
+                    out_temp, out_humid, out_weather, out_wind,
+                )
+                save_log(log_row)
+                print(f"💾 [Log] {LOG_FILE} 저장 완료\n")
             else:
-                print("  → 쾌적 상태 유지 (변경 없음)")
-                target_temp = hvac.target_temp
-                fan_speed   = hvac.fan_speed
+                print("⚠️ [Manual] 분석 실패\n")
 
-            # ── CSV 로그 저장 ─────────────────────────────────────────────────
-            save_log({
-                'timestamp':      datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-                'scenario':       SCENARIO_NAME,
-                'system_state':   current_state.value,
-                'departure_score': sm.departure_score,
-                'out_temp':       out_temp,
-                'out_humid':      out_humid,
-                'out_weather':    out_weather,
-                'out_wind':       out_wind,
-                'in_temp':        hvac.indoor_temp,
-                'in_humid':       hvac.indoor_humid,
-                'people_count':   last_people_count,
-                'met':            vlm_data['met'],
-                'clo':            vlm_data['clo'],
-                'activity':       vlm_data['activity'],
-                'bags':           vlm_data['bags'],
-                'heat_source':    vlm_data['heat_source'],
-                'window_open':    hvac.window_open,
-                'room_size':      hvac.room_size,
-                'air_vel':        air_vel,
-                'pmv_val':        pmv_val,
-                'comfort_status': comfort_msg,
-                'target_temp':    target_temp,
-                'fan_speed':      fan_speed,
-                'power_w':        em.get_current_power_w(hvac.is_on, hvac.fan_speed),
-                'energy_kwh':     em.get_energy_kwh(),
-                'baseline_kwh':   em.get_baseline_kwh(),
-                'savings_pct':    em.get_savings_pct(),
-                'comfort_rate':   em.get_comfort_rate(),
-            })
-            print(f"💾 [Log] {LOG_FILE} 에 저장 완료\n")
-
-        # ── 종료 ('q') ────────────────────────────────────────────────────────
+        # ── 종료 ('q') ───────────────────────────────────────────────────────
         elif key == ord('q'):
-            print("\n👋 프로그램을 종료합니다.")
+            print("\n👋 프로그램 종료 중...")
+            stop_event.set()
+            vlm_thread.join(timeout=5)
             em.print_summary()
             break
 
@@ -333,4 +383,10 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description='VLM 기반 지능형 HVAC 제어 시스템')
+    parser.add_argument(
+        '--interval', type=int, default=30,
+        help='자동 VLM 분석 주기 (초, 기본값: 30 / Jetson 권장: 5~10)'
+    )
+    args = parser.parse_args()
+    main(analysis_interval=args.interval)

--- a/motion_detector.py
+++ b/motion_detector.py
@@ -1,0 +1,96 @@
+import cv2
+import numpy as np
+from collections import deque
+
+
+class MotionDetector:
+    """
+    [실시간 모션 감지기]
+    OpenCV 프레임 차분 + Gaussian blur + 롤링 평균으로
+    실제 움직임 강도를 측정하여 PMV 대사율(MET)을 보정합니다.
+
+    ── 알고리즘 ──────────────────────────────────────────────────────────────
+    1. 연속 두 프레임의 그레이스케일 차분 (absdiff)
+    2. Gaussian blur로 조명 깜빡임·카메라 노이즈(고주파) 제거
+    3. 픽셀 평균 밝기 = motion_score (움직임 강도)
+    4. 최근 N프레임 롤링 평균 → 순간 통행자에 의한 오탐 방지
+
+    ── MET 변환 기준 ──────────────────────────────────────────────────────
+    score ≥ MOTION_HIGH (15.0) : 3.0 met  (운동, exercising)
+    score ≥ MOTION_MED  ( 5.0) : 1.5 met  (보행, walking)
+    score ≥ MOTION_LOW  ( 1.5) : 1.2 met  (기립/서성임, standing)
+    score <  MOTION_LOW        : None      (VLM 정적 판단 신뢰)
+
+    ── VLM override 기준 ──────────────────────────────────────────────────
+    score ≥ MOTION_MED (5.0) 이면 motion_met 우선 사용.
+    그 이하에서는 VLM의 activity 기반 MET를 신뢰.
+    (VLM의 clo·count·bags·heat_source는 motion과 무관하게 항상 VLM 값 사용)
+    """
+
+    MOTION_HIGH = 15.0   # MET 3.0 (운동) 임계값
+    MOTION_MED  =  5.0   # MET 1.5 (보행) 임계값 / VLM override 기준
+    MOTION_LOW  =  1.5   # MET 1.2 (기립) 임계값
+
+    def __init__(self, history_len: int = 10, blur_ksize: int = 21):
+        """
+        Args:
+            history_len : 롤링 평균 윈도우 크기 (프레임 수, 기본값: 10)
+            blur_ksize  : Gaussian blur 커널 크기 (홀수, 기본값: 21)
+        """
+        self._prev_gray     = None
+        self._score_history = deque(maxlen=history_len)
+        self._current_score = 0.0
+        self._blur_ksize    = (blur_ksize, blur_ksize)
+
+    # ── 공개 API ──────────────────────────────────────────────────────────────
+
+    def update(self, frame) -> float:
+        """
+        새 프레임을 받아 motion_score를 갱신하고 반환합니다.
+        메인 루프 매 프레임마다 호출합니다.
+
+        Returns:
+            float: 현재 롤링 평균 motion_score (0 이상)
+        """
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+        if self._prev_gray is None:
+            self._prev_gray = gray
+            return 0.0
+
+        diff      = cv2.absdiff(self._prev_gray, gray)
+        blurred   = cv2.GaussianBlur(diff, self._blur_ksize, 0)
+        raw_score = float(np.mean(blurred))
+
+        self._score_history.append(raw_score)
+        self._current_score = float(np.mean(self._score_history))
+        self._prev_gray     = gray
+
+        return self._current_score
+
+    def get_motion_met(self) -> float | None:
+        """
+        현재 motion_score를 ISO 7730 MET 값으로 변환합니다.
+
+        Returns:
+            float : motion 기반 MET 값 (score ≥ MOTION_LOW 일 때)
+            None  : score < MOTION_LOW — VLM 정적 판단을 신뢰하라는 신호
+        """
+        s = self._current_score
+        if s >= self.MOTION_HIGH:
+            return 3.0
+        elif s >= self.MOTION_MED:
+            return 1.5
+        elif s >= self.MOTION_LOW:
+            return 1.2
+        return None
+
+    def should_override_vlm(self) -> bool:
+        """
+        motion_score ≥ MOTION_MED 이면 VLM activity-MET를 override합니다.
+        """
+        return self._current_score >= self.MOTION_MED
+
+    @property
+    def current_score(self) -> float:
+        return self._current_score


### PR DESCRIPTION
- motion_detector.py 신규: · OpenCV 프레임 차분 + Gaussian blur + 롤링 평균(10프레임) · motion_score → MET 변환 (LOW=1.5/MED=5.0/HIGH=15.0 임계값) · should_override_vlm(): score≥5.0이면 VLM activity-MET 대체 · 단일 프레임으로 감지 불가한 walking/exercising 보완

- main.py 전면 재작성 (threading 아키텍처): · vlm_worker() 백그라운드 스레드: interval마다 자동 VLM 실행
    - Queue(maxsize=1)로 최신 결과만 유지
    - frame_lock으로 프레임 공유 안전 처리
    - stop_event로 'q' 키 시 정상 종료 · 메인 루프: result_queue 비블로킹 폴링 → 화면 30fps 유지 · process_vlm_result() 분리: MET 우선순위 + 제어 파이프라인 · MET 결정: motion override(score≥5.0) 또는 VLM 정적 판단 · argparse --interval 인수: 기본 30초, Jetson에서 5~10초로 조정 · 's' 키: 즉시 동기 분석 유지 (디버깅용) · CSV 신규 컬럼: motion_score, met_source