### PR TITLE
fix: macOS/Jetson 하이브리드 OS 호환성 자동 분기

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import cv2
 import os
+import platform
 import queue
 import threading
 import time
@@ -225,7 +226,12 @@ def main(analysis_interval: int = 30):
     cv2.putText(dummy_frame, "No Camera Available", (50, 100),
                 cv2.FONT_HERSHEY_SIMPLEX, 0.7, (200, 200, 200), 2)
 
-    cap = cv2.VideoCapture(0, cv2.CAP_AVFOUNDATION)
+    # macOS: CAP_AVFOUNDATION 백엔드 사용 (권한 안정성)
+    # Linux/Jetson: 기본 백엔드 사용
+    if platform.system() == "Darwin":
+        cap = cv2.VideoCapture(0, cv2.CAP_AVFOUNDATION)
+    else:
+        cap = cv2.VideoCapture(0)
     if not cap.isOpened():
         print("카메라를 열 수 없습니다. 시뮬레이션 모드로 전환합니다.")
         use_camera = False
@@ -241,7 +247,7 @@ def main(analysis_interval: int = 30):
         if use_camera:
             print("카메라가 성공적으로 연결되었습니다.")
         else:
-            print("카메라 프레임 읽기 실패. 시스템 설정 > 개인정보 > 카메라 권한을 확인하세요.")
+            print("카메라 프레임 읽기 실패. 카메라 권한을 확인하세요.")
             cap.release()
 
     # ── 스레드 설정 ───────────────────────────────────────────────────────────

--- a/state_machine.py
+++ b/state_machine.py
@@ -31,7 +31,7 @@ class StateManager:
     최대 점수    : 75점
     """
 
-    ARRIVAL_DURATION_SEC = 60    # 도착 후 강제 제어 지속 시간 (1분, 개발환경)
+    ARRIVAL_DURATION_SEC = 60 if __import__('platform').system() == "Darwin" else 600  # macOS: 1분, Jetson: 10분
     EMPTY_CONFIRM_SEC    = 30    # 인원 0 확인 후 EMPTY 전환까지 대기 (30초)
     DEPARTURE_SCORE_ON   = 55    # PRE_DEPARTURE 진입 임계값
     DEPARTURE_SCORE_OFF  = 30    # STEADY 복귀 임계값 (히스테리시스)


### PR DESCRIPTION
## 변경 사항

- **main.py**: `platform.system()` 으로 OS 감지
  - macOS → `CAP_AVFOUNDATION` 카메라 백엔드
  - Linux/Jetson → 기본 백엔드
- **state_machine.py**: ARRIVAL → STEADY 전환 시간 자동 분기
  - macOS → 60초 (개발 환경)
  - Linux/Jetson → 600초 (실배포 환경)

코드 변경 없이 맥북/Jetson 양쪽에서 동일한 코드로 실행 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)