### PR TITLE
chore: .claude 로컬 설정 추적 제거

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(/opt/homebrew/Caskroom/miniconda/base/envs/fastvlm/bin/pip list:*)",
-      "Bash(/opt/homebrew/Caskroom/miniconda/base/envs/fastvlm/bin/pip install:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ hvac_system_performance.csv
 ppt_build/
 ~$*.pptx
 VLM_HVAC_Capstone.pptx
+
+# Claude Code 로컬 설정 전체 무시 (CLAUDE.md는 추적 유지)
+.claude/


### PR DESCRIPTION
공개 저장소에서 개발자 로컬 Claude Code 설정(settings.local.json)을 추적 제거하고 .claude/를 gitignore에 추가. CLAUDE.md(프로젝트 문서)는 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)